### PR TITLE
400 team c task test questions from llm create llm service skeleton

### DIFF
--- a/Team-C/test_wizard/android/app/src/main/AndroidManifest.xml
+++ b/Team-C/test_wizard/android/app/src/main/AndroidManifest.xml
@@ -42,4 +42,5 @@
             <data android:mimeType="text/plain"/>
         </intent>
     </queries>
+    <uses-permission android:name="android.permission.INTERNET"/>
 </manifest>

--- a/Team-C/test_wizard/lib/services/llm_service.dart
+++ b/Team-C/test_wizard/lib/services/llm_service.dart
@@ -2,25 +2,21 @@ import 'package:http/http.dart' as http;
 import 'dart:convert';
 
 class LLMService {
-  String
-      url; // would this come from a provider? As in llm = new LLMProvider(), then llm.url, llm.apiKey, etc.
+  String url = 'https://api.perplexity.ai/chat/completions';
   String apiKey = const String.fromEnvironment('API_KEY');
+  http.Response? response;
 
-  LLMService({
-    this.url = 'https://api.perplexity.ai/chat/completions',
-  }); // or this.llm = new LLMProvider?
+  LLMService();
 
   Future<http.Response> sendRequest(String prompt) {
     return http.post(
       Uri.parse(url),
       headers: <String, String>{
-        // or llm.generateHeaders()?
         'Accept': 'application/json',
         'Content-Type': 'application/json',
         'Authorization': 'Bearer $apiKey'
       },
       body: jsonEncode({
-        // or llm.generateBody()?
         'model': 'llama-3-sonar-small-32k-online',
         'messages': [
           {

--- a/Team-C/test_wizard/lib/services/llm_service.dart
+++ b/Team-C/test_wizard/lib/services/llm_service.dart
@@ -1,0 +1,38 @@
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+class LLMService {
+  String
+      url; // would this come from a provider? As in llm = new LLMProvider(), then llm.url, llm.apiKey, etc.
+  String apiKey = const String.fromEnvironment('API_KEY');
+
+  LLMService({
+    this.url = 'https://api.perplexity.ai/chat/completions',
+  }); // or this.llm = new LLMProvider?
+
+  Future<http.Response> sendRequest(String prompt) {
+    return http.post(
+      Uri.parse(url),
+      headers: <String, String>{
+        // or llm.generateHeaders()?
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $apiKey'
+      },
+      body: jsonEncode({
+        // or llm.generateBody()?
+        'model': 'llama-3-sonar-small-32k-online',
+        'messages': [
+          {
+            'role': 'system',
+            'content': 'Be precise and return json only.',
+          },
+          {
+            'role': 'user',
+            'content': 'Give me a multiple choice geometry question.',
+          }
+        ]
+      }),
+    );
+  }
+}

--- a/Team-C/test_wizard/lib/services/llm_service.dart
+++ b/Team-C/test_wizard/lib/services/llm_service.dart
@@ -4,7 +4,6 @@ import 'dart:convert';
 class LLMService {
   String url = 'https://api.perplexity.ai/chat/completions';
   String apiKey = const String.fromEnvironment('API_KEY');
-  http.Response? response;
 
   LLMService();
 

--- a/Team-C/test_wizard/lib/services/llm_service.dart
+++ b/Team-C/test_wizard/lib/services/llm_service.dart
@@ -7,8 +7,8 @@ class LLMService {
 
   LLMService();
 
-  Future<http.Response> sendRequest(String prompt) {
-    return http.post(
+  Future<http.Response> sendRequest(http.Client httpClient, String prompt) {
+    return httpClient.post(
       Uri.parse(url),
       headers: <String, String>{
         'Accept': 'application/json',

--- a/Team-C/test_wizard/lib/services/llm_service.dart
+++ b/Team-C/test_wizard/lib/services/llm_service.dart
@@ -25,11 +25,11 @@ class LLMService {
         'messages': [
           {
             'role': 'system',
-            'content': 'Be precise and return json only.',
+            'content': 'You are a teacher creating tests for your students.',
           },
           {
             'role': 'user',
-            'content': 'Give me a multiple choice geometry question.',
+            'content': prompt,
           }
         ]
       }),

--- a/Team-C/test_wizard/pubspec.yaml
+++ b/Team-C/test_wizard/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.6
+  http: ^1.2.1
 
 dev_dependencies:
   flutter_test:

--- a/Team-C/test_wizard/test/services_tests/llm_service_test.dart
+++ b/Team-C/test_wizard/test/services_tests/llm_service_test.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart';
+import 'package:http/testing.dart';
+import 'package:test_wizard/services/llm_service.dart';
+
+void main() {
+  group('LLM Service', () {
+    test('constructor correctly instantiates class', () {
+      final llm = LLMService();
+      expect(llm.url, 'https://api.perplexity.ai/chat/completions');
+      expect(llm.apiKey, const String.fromEnvironment('API_KEY'));
+    });
+
+    // mock successful response from AI, probably not what it actually looks like
+    final response = {
+      'questions': [
+        {
+          'question': 'What is the powerhouse of the cell',
+          'type': 'multiple choice',
+          'choice1': 'mitochondria',
+          'choice2': 'vacuole',
+          'choice3': 'nucleus',
+          'choice4': 'the limit does not exist',
+          'answer': 'the limit does not exist',
+        }
+      ]
+    };
+
+    test('makes call to API', () async {
+      final llm = LLMService();
+      final mockHTTPClient = MockClient((_) async {
+        return Response(jsonEncode(response), 200);
+      });
+
+      expect(llm.sendRequest(mockHTTPClient, 'this is my prompt'),
+          isInstanceOf<Future<Response>>());
+    });
+  });
+}


### PR DESCRIPTION
## Proposed changes

This would set up the LLMService class, responsible for sending requests to the LLM. Unit testing for `LLMService` constructor and `LLMService.sendRequest()` included.

**IMPORTANT**: I think (not 100% sure on this) you will have to run `flutter pub get` to update your versions of the dependencies I added (dart's standard `http` package). 

### Future Work

We may want to extend the reach of this class into returning specific data or catching errors as necessary, but for now it just makes the API call and returns the `Future<Response>`.

Reviews appreciated. :)