### PR TITLE
added title, name, date, and space between questions for print…

### DIFF
--- a/Team-C/test_wizard/lib/views/modify_test_view.dart
+++ b/Team-C/test_wizard/lib/views/modify_test_view.dart
@@ -36,7 +36,7 @@ class ModifyTestView extends StatelessWidget {
               const SizedBox(height: 20),
               const ColumnHeaderRow(),
               QSet(assessmentId: assessmentId),
-              const ButtonContainer(),
+              ButtonContainer(screenTitle: screenTitle),
               const EditPrompt(),
               const DeletedQuestions(),
             ],
@@ -56,10 +56,10 @@ class ColumnHeaderRow extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
         Expanded(child: ColumnHeader(headerText: 'Question')),
-        Expanded(
+        Flexible(
+          fit: FlexFit.tight,
           child: Padding(
-            padding:
-                EdgeInsets.only(left: 24.0), // Adjust the padding as needed
+            padding: EdgeInsets.only(left: 120.0), // Adjust the padding as needed
             child: ColumnHeader(headerText: 'Answer'),
           ),
         ),
@@ -70,7 +70,9 @@ class ColumnHeaderRow extends StatelessWidget {
 }
 
 class ButtonContainer extends StatelessWidget {
-  const ButtonContainer({super.key});
+  final String screenTitle;
+
+  const ButtonContainer({super.key, required this.screenTitle});
 
   void _printQuestionsAndAnswers(BuildContext context) {
     final questions =
@@ -82,16 +84,20 @@ class ButtonContainer extends StatelessWidget {
         build: (pw.Context context) {
           return pw.Column(
             crossAxisAlignment: pw.CrossAxisAlignment.start,
-            children: questions.map((qa) {
-              return pw.Column(
-                crossAxisAlignment: pw.CrossAxisAlignment.start,
-                children: [
-                  pw.Text('Question: ${qa.questionText}'),
-                  pw.Text('Answer: ${qa.answerText}'),
-                  pw.SizedBox(height: 20),
-                ],
-              );
-            }).toList(),
+            children: [
+              pw.Text(screenTitle, style: pw.TextStyle(fontSize: 24, fontWeight: pw.FontWeight.bold)),
+              pw.SizedBox(height: 20),
+              ...questions.map((qa) {
+                return pw.Column(
+                  crossAxisAlignment: pw.CrossAxisAlignment.start,
+                  children: [
+                    pw.Text('Question: ${qa.questionText}'),
+                    pw.Text('Answer: ${qa.answerText}'),
+                    pw.SizedBox(height: 20),
+                  ],
+                );
+              }).toList(),
+            ],
           );
         },
       ),
@@ -112,15 +118,23 @@ class ButtonContainer extends StatelessWidget {
         build: (pw.Context context) {
           return pw.Column(
             crossAxisAlignment: pw.CrossAxisAlignment.start,
-            children: questions.map((qa) {
-              return pw.Column(
-                crossAxisAlignment: pw.CrossAxisAlignment.start,
-                children: [
-                  pw.Text('Question: ${qa.questionText}'),
-                  pw.SizedBox(height: 20),
-                ],
-              );
-            }).toList(),
+            children: [
+              pw.Text(screenTitle, style: pw.TextStyle(fontSize: 24, fontWeight: pw.FontWeight.bold)),
+              pw.SizedBox(height: 20),
+              pw.Text('Student Name:', style: pw.TextStyle(fontSize: 18)),
+              pw.SizedBox(height: 20),
+              pw.Text('Date:', style: pw.TextStyle(fontSize: 18)),
+              pw.SizedBox(height: 60), 
+              ...questions.map((qa) {
+                return pw.Column(
+                  crossAxisAlignment: pw.CrossAxisAlignment.start,
+                  children: [
+                    pw.Text('Question: ${qa.questionText}'),
+                    pw.SizedBox(height: 80), 
+                  ],
+                );
+              }).toList(),
+            ],
           );
         },
       ),


### PR DESCRIPTION
...buttons and also fix bug for column header alignment

-Print Questions and Answers: Added the screen title at the top of the printed document.
-Print Questions Only:
     *added the screen title and a static label "Student Name:" at the top
     *increased the space between the "Student Name:" label and the first question
     *increased the space between each question 

 -Alignment Adjustment for "Answer" Column Header:
     *replaced Expanded with Flexible for the "Answer" header to provide more precise control over its placement
     *added Padding with EdgeInsets.only(left: 120.0) to move the header approximately half an inch to the right

Thank you for your review.

-Whitney Meulink 
![print only questions with name](https://github.com/user-attachments/assets/6691db82-bede-4a92-bca2-5c99973daea1)
![print with title](https://github.com/user-attachments/assets/45d8a428-2c22-43be-9d4f-e5d977623069)
![column header](https://github.com/user-attachments/assets/b9672d93-d186-4391-af02-fc10060fd33a)
